### PR TITLE
Add optional manual Bluetooth photo mode for PicPak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Added
+- Bluetooth photo connections now report battery voltage, low-voltage status,
+  refresh speed and screen mode to Companion without starting Wi-Fi.
+- **Manual Bluetooth photo mode.** Choose Automatic (Wi-Fi) or Manual (Bluetooth)
+  in Companion's PicPak maintenance screen. Manual mode pauses scheduled network
+  updates and heartbeats, sleeps until a button press, and receives photos directly
+  from an authorized iPhone. Wi-Fi/server settings and refresh speed are retained.
+- Photo authorization is established through authenticated maintenance and stored
+  on the display. Returning to Automatic mode or performing Factory Reset revokes
+  photo authorization. Complete uploads are verified before refreshing; cancelled
+  or incomplete photo sessions leave the existing picture intact.
+
+### Fixed
+- Leaving Bluetooth maintenance in Manual mode now shows how to send a photo
+  with one button press, replacing the misleading "Bluetooth closed" Wi-Fi
+  message. A consistent text size, numbered steps and aligned spacing make
+  the guide easier to follow. The expired QR code is still cleared before sleeping.
+- Maintenance entry guidance follows the upstream 10-second hold in Manual
+  Bluetooth mode as well as Automatic mode.
+
 ## 0.9.4
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.9.5
+
 ### Added
 - Bluetooth photo connections now report battery voltage, low-voltage status,
   refresh speed and screen mode to Companion without starting Wi-Fi.
@@ -15,6 +17,15 @@
   or incomplete photo sessions leave the existing picture intact.
 
 ### Fixed
+- Manual (Bluetooth) mode now gives its own low-battery feedback and recovers on
+  its own. When the cell reaches the low-battery gate it paints the "battery low —
+  please charge" splash (on a button press or a silent 24-hour battery check) and
+  keeps the radio off; previously it slept button-only with no on-screen warning and
+  no scheduled re-check. It re-checks every 24 hours and, once charged past the
+  recovery threshold, paints the "Bluetooth photos" ready screen so an untouched
+  device recovers unattended. A brownout reset now defers with a short recovery
+  sleep instead of waiting only for a button. Diagnostic log line added
+  (`manual mode: battery … mV, gate=…`) for hardware verification.
 - Leaving Bluetooth maintenance in Manual mode now shows how to send a photo
   with one button press, replacing the misleading "Bluetooth closed" Wi-Fi
   message. A consistent text size, numbered steps and aligned spacing make

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Modelled on Tesserae's battery-native reference client
 but retargeted to the PicPak's hardware: a smaller 4-colour panel, an ESP32-C3 (RISC-V) instead of an
 S3, no PMIC (battery is read straight off an ADC), and a 2-bits-per-pixel frame format.
 
-> **Status:** working end-to-end over REST, MQTT, and cloud relay on real hardware. `FW_VERSION 0.9.4`.
+> **Status:** working end-to-end over REST, MQTT, and cloud relay on real hardware. `FW_VERSION 0.9.5`.
 > See [`CHANGELOG.md`](CHANGELOG.md) for release notes.
 > Tested on PicPak **hardware revision v0.0.1**, migrating from **official firmware v1.1.11**
 > to this firmware and back (stock restore verified).
@@ -417,7 +417,7 @@ precedes the paint by its 13 to 22 s duration):
   "battery_pct": 96,
   "rssi": -63,
   "ip": "10.0.20.40",
-  "fw_version": "0.9.4",
+  "fw_version": "0.9.5",
   "kind": "picpak_client",
   "panel_w": 400,
   "panel_h": 300,

--- a/docs/ble-maintenance.md
+++ b/docs/ble-maintenance.md
@@ -23,15 +23,17 @@ initial server setup.
 The display paints a QR code and passkey before advertising. Open Bluetooth
 Maintenance in Companion, select the nearby PicPak, then scan the QR code or use
 the six-digit passkey. The five-minute deadline starts after screen rendering.
-Closing the app disconnects the phone; the same physical session can be rejoined
-until that deadline. Deep sleep never advertises. Low-battery protection still
+Closing the sheet disconnects the phone. In Automatic mode, an unchanged
+maintenance session can be rejoined until its deadline. After changing Screen Mode,
+or after authenticated maintenance in Manual mode, disconnecting ends maintenance
+and applies the selected mode. Deep sleep never advertises. Low-battery protection still
 applies to entry.
 
 To leave without a phone, briefly press and release the wake button after the
 QR screen is ready. The entry hold must first be released; a fresh press shorter
 than three seconds exits on release. Long holds have no action inside maintenance.
 The radio stops, the expired QR is cleared, and the display restarts its normal
-network cycle. Saved settings, including refresh speed, are retained; pending
+operation (network cycle or button-only sleep). Saved settings, including refresh speed, are retained; pending
 commands and staged but unsaved credentials are discarded. The five-minute
 deadline remains the fallback, even if a button is held or bouncing.
 
@@ -40,7 +42,7 @@ and repair are explicit actions. Wi-Fi repair tests association and DHCP, then
 saves only Wi-Fi credentials; it does not contact Tesserae or replace REST,
 MQTT, relay, or server-registration settings. Clearing Wi-Fi opens one recovery
 session after restarting, then falls back to AP setup if it times out. Factory
-Reset clears stored application settings and returns to AP setup. Neither reset
+Reset clears stored application settings, including photo authorization, and returns to AP setup. Neither reset
 operation reflashes the firmware.
 
 The normal image deduplication references are cleared when painting the QR so
@@ -55,6 +57,21 @@ drivers or waveforms. They control redraw duration, not the schedule between
 updates. Faster modes trade colour margin for speed; Native uses the panel's
 built-in waveform. Approximate duration depends on the panel and conditions.
 Saving does not force an extra refresh; it applies at the next `epd_init()`.
+
+## Screen mode
+
+Updated Companion shows **Screen Mode** when diagnostics reports `screen_mode`.
+Choose **Automatic (Wi-Fi)** for normal server updates or **Manual (Bluetooth)**
+for button-triggered local photo reception. Manual mode works without a saved
+SSID or reachable server. Close Maintenance, wait for the closing screen to
+finish, then press the button once with Companion open to send a photo.
+
+The existing refresh waveform is used for photos. Hold for 10 seconds and release
+before 20 seconds to open maintenance; a 5-second hold in Manual mode also opens
+photo reception. Completing explicit 20-second AP provisioning returns the display
+to Automatic mode.
+See [BLE photo protocol and validation](ble-photo.md) for authorization, timing,
+compatibility, and the complete wire contract.
 
 ## Wire contract
 

--- a/docs/ble-photo.md
+++ b/docs/ble-photo.md
@@ -1,0 +1,133 @@
+# PicPak manual Bluetooth photos (v1)
+
+This extends Tesserae BLE v2; it is not an OpenDisplay implementation. The scope
+is the 400×300 PicPak and the matching Tesserae Companion build. No server change
+is required to send a local photo.
+
+## Operation
+
+- Default: Automatic (Wi-Fi); existing REST/MQTT/relay settings remain unchanged.
+- Select Manual (Bluetooth) in authenticated Maintenance. Its acknowledgement
+  also authorizes this iPhone. Close the sheet; the QR is replaced by a Bluetooth
+  mode guide: open Tesserae, press the button once, then tap Send to choose a photo.
+  The display restarts into GPIO-only deep sleep. No Wi-Fi, timer heartbeat,
+  or periodic BLE advertisement runs in this mode.
+- A short button wake opens a connectable photo advertisement. A tap released
+  before the boot gesture reader runs still works via the GPIO wake cause.
+- No connection/authenticated command: 90 seconds. After an authenticated command:
+  5 minutes idle, with a 10-minute absolute session limit. Advertising interval
+  is 100–150 ms during this bounded window. BLE is off between sessions.
+- Hold for 10 seconds and release before 20 seconds to enter Maintenance.
+  A 5-second hold opens photo reception
+  in Manual mode. A successful explicit 20-second AP setup selects Automatic.
+- The app must be open to discover and show a compact photo invitation. Tap
+  **Send** to connect and open the photo editor. This is an in-app sheet, not a
+  global iOS proximity prompt. A sleeping display cannot be remotely
+  awakened over BLE.
+- Select/crop/Auto Frame a photo, then Send. The phone handles resizing, nominal
+  BWRY quantization, Floyd–Steinberg dithering and packing without a server.
+  Custom server calibration profiles are not imported in v1.
+- Transfer completion verifies SHA-256. The radio is shut down before the existing
+  panel driver refreshes, to avoid overlapping radio/display current peaks.
+  `photo_received` acknowledges verified reception, **not physical refresh success**.
+- Cancel, disconnect, missing chunks or checksum failure never refresh partial
+  data. The photo session does not paint a QR, instructions, or a closing splash.
+  Maintenance continues to paint its existing QR/closing screens.
+
+Manual mode intentionally stops automatic server content and telemetry. A server
+may show this display as stale/offline. To resume server-managed updates, select
+Automatic in Maintenance; saved network credentials and transport are retained.
+No separate firmware, partition migration, or display waveform change is needed.
+
+## Authorization and mode setting
+
+On the existing maintenance service (`7A5E0001-7B6D-4F8B-9C2E-1D0A5A110001`),
+authenticate using the current QR AES-GCM flow or authenticated LE Secure
+Connections passkey flow. Diagnostics adds `screen_mode: "wifi" | "bluetooth"`.
+Older firmware omits this field, so the new picker stays hidden.
+
+Send `{"op":"set_screen_mode","value":"bluetooth","request":123}`.
+After one successful NVS commit, receive:
+`{"event":"screen_mode","value":"bluetooth","request":123,"photo_key":"<base64url>"}`.
+`request` is an unsigned 32-bit correlation ID. The key contains 32 random bytes.
+It is delivered only through the authenticated maintenance channel. Selecting
+Bluetooth again returns the existing key, allowing another physically authorized
+phone to join. Selecting Wi-Fi or Factory Reset revokes all photo keys; Clear
+Wi-Fi preserves photo mode and authorization. A failed commit returns `error`.
+
+Mode and key are a single `state/photo_config` NVS blob (mode byte + 32 key bytes).
+The iPhone stores the key under the immutable BLE device ID in Keychain with
+`WhenUnlockedThisDeviceOnly` accessibility. Mode acknowledgement and local key
+storage are separate outcomes: a Keychain failure is shown and can be retried.
+
+## Discovery and security
+
+Photo service: `7A5E0007-7B6D-4F8B-9C2E-1D0A5A110001`.
+Its ten-byte service advertisement retains major **2**, hardware **11**, mode
+**0x04**, hardware suffix and random four-byte physical session ID. A distinct
+service prevents old apps from mistaking photo reception for setup/diagnostics.
+
+Characteristics retain the info/control/event suffixes 0002/0003/0005. Binary
+photo data uses suffix **0006**. The passkey endpoint is unavailable in a photo
+session. Only photo operations are allowed; network/config/reset/key retrieval
+commands are rejected.
+
+The info characteristic supplies the immutable device ID, advertised session ID,
+model `picpak_4_2`, mode `photo`, and a fresh 16-byte nonce per connection. The phone
+uses its stored photo key in the existing v2 HKDF-SHA256/AES-256-GCM envelope.
+Directional counters and connection nonces remain mandatory. The binary endpoint
+shares the authenticated counter stream, but has its own message reassembler.
+Plain native events cannot be accepted by an app using the encrypted envelope.
+
+## Transfer contract
+
+Control commands and events are JSON, at most 512 bytes, framed using BLE v2.
+The separate binary characteristic also uses v2 encrypted chunk framing around
+one binary packet. All writes use ATT Write With Response. Do not base64-encode
+an entire image into a control message.
+
+1. `photo_info` -> `photo_info` event with version=1, width=400, height=300,
+   bytes=30000, chunk_bytes=192, format=`picpak-bwry2-bottom-up`.
+   It also returns optional `battery_mv`, `low_battery`, `refresh_speed`
+   (`5s`/`10s`/`native`) and `screen_mode` (`wifi`/`bluetooth`). Battery voltage
+   is the cached reading taken on this wake before radio/display load, not a
+   live charging indicator. `low_battery` means a valid reading below the
+   existing 3400 mV low-voltage threshold; it does not change the protection
+   gate. Implausible readings outside 2500–5000 mV return null for both battery
+   fields. Status is sent over the authenticated connection, without Wi-Fi or
+   additional advertising. Older apps ignore these fields; newer apps omit
+   unavailable values when connected to older photo firmware. Firmware/model
+   remain available in the existing info characteristic.
+2. `photo_begin` supplies nonzero UInt32 `id`, `bytes`=30000, that exact `format`,
+   and a lowercase 64-character `sha256`. It starts/restarts the bounded buffer
+   and returns `photo_ack` with matching `id` and `offset`=0.
+3. Binary messages contain `[id:4 big endian][offset:4 big endian][pixels:1..192]`.
+   `photo_ack` returns the next expected byte offset. Stop and wait for the ACK
+   before sending the next chunk. Duplicates succeed only if their bytes exactly
+   match already received data. Future offsets, overflow and other IDs/generations
+   are rejected. The phone retries a missing ACK at most twice after 8 seconds,
+   using fresh encrypted frames; it never replays ciphertext.
+4. `photo_end` supplies the same `id`. All 30000 bytes and the SHA-256 must match.
+   `photo_received` with that ID precedes radio shutdown and panel refresh.
+5. `photo_cancel` -> `photo_cancelled`, then shutdown. Closing/disconnecting also
+   cancels an unfinished upload. A new connection always starts a new upload.
+
+Pixels are row-major **bottom row first**; four pixels per byte, most significant
+bits first. Palette indices: 0 black, 1 white, 2 yellow, 3 red. Therefore B/W/Y/R
+packs to `0x1b`. This matches the existing PicPak driver and Tesserae renderer.
+
+## Validation boundary
+
+Run `tools/test_host.sh` for the C receiver, cross-platform BLE crypto vector,
+NVS mode/key persistence and revocation, and existing maintenance regressions.
+Run `tools/build_firmware.sh` for the ESP32-C3 image and 2 MiB slot size check.
+Companion has `BLEPhotoTests` (packing/orientation/crop/ACK/keychain) and PicPak
+UI journeys. Radio UI fixtures exercise the real manager and encoder but replace
+the physical peripheral; they do not establish BLE interoperability or power use.
+
+Before a hardware release verify on PicPak: QR and passkey authorization; switch
+modes/reboot; single short taps; no Wi-Fi or timer wakeups in Manual mode; a real
+photo's colors/row order/crop; 5s/10s/Native refresh; phone loss/cancel/checksum
+failure; recovery through Maintenance; low battery; and resuming every previously
+configured network transport. Actual throughput, power draw and panel behavior
+require a physical device.

--- a/docs/ble-photo.md
+++ b/docs/ble-photo.md
@@ -10,8 +10,10 @@ is required to send a local photo.
 - Select Manual (Bluetooth) in authenticated Maintenance. Its acknowledgement
   also authorizes this iPhone. Close the sheet; the QR is replaced by a Bluetooth
   mode guide: open Tesserae, press the button once, then tap Send to choose a photo.
-  The display restarts into GPIO-only deep sleep. No Wi-Fi, timer heartbeat,
-  or periodic BLE advertisement runs in this mode.
+  The display restarts into deep sleep, woken by the button or a silent 24-hour
+  low-power battery check. No Wi-Fi, network heartbeat, or periodic BLE
+  advertisement runs in this mode; the 24-hour wake reads the cell and sleeps
+  again without bringing up any radio.
 - A short button wake opens a connectable photo advertisement. A tap released
   before the boot gesture reader runs still works via the GPIO wake cause.
 - No connection/authenticated command: 90 seconds. After an authenticated command:
@@ -33,6 +35,17 @@ is required to send a local photo.
 - Cancel, disconnect, missing chunks or checksum failure never refresh partial
   data. The photo session does not paint a QR, instructions, or a closing splash.
   Maintenance continues to paint its existing QR/closing screens.
+
+Low battery in Manual mode is self-signalling, since there is no server to paint a
+charge screen. When the cell reaches the low-battery gate (the same threshold and
+2-read debounce as the Wi-Fi path), the panel paints the "battery low — please
+charge" splash — on a button press or on the 24-hour check — and never brings up
+the BLE radio on a weak cell. It keeps re-checking every 24 hours; once the cell
+charges back above the recovery threshold it paints a "ready for photos" screen,
+clearing the charge splash so an untouched device recovers on its own. A brownout
+reset defers with a short recovery sleep instead of waiting button-only. Pressing
+the button after charging shows "ready" only once the cell has passed the recovery
+threshold; a marginally-charged cell stays on the charge splash.
 
 Manual mode intentionally stops automatic server content and telemetry. A server
 may show this display as stale/offline. To resume server-managed updates, select
@@ -126,8 +139,17 @@ UI journeys. Radio UI fixtures exercise the real manager and encoder but replace
 the physical peripheral; they do not establish BLE interoperability or power use.
 
 Before a hardware release verify on PicPak: QR and passkey authorization; switch
-modes/reboot; single short taps; no Wi-Fi or timer wakeups in Manual mode; a real
-photo's colors/row order/crop; 5s/10s/Native refresh; phone loss/cancel/checksum
-failure; recovery through Maintenance; low battery; and resuming every previously
-configured network transport. Actual throughput, power draw and panel behavior
-require a physical device.
+modes/reboot; single short taps; no Wi-Fi, network, or BLE-advertising wakeups in
+Manual mode (only the silent 24-hour battery poll); a real photo's colors/row
+order/crop; 5s/10s/Native refresh; phone loss/cancel/checksum failure; recovery
+through Maintenance; and resuming every previously configured network transport.
+For Manual-mode low battery specifically, verify on a drained cell: the charge
+splash paints on a button press and on the 24-hour check; the device re-checks and
+stays asleep while low; charging past the recovery threshold paints the "ready for
+photos" screen (on the 24-hour check or a button press); and a brownout reset
+defers with a short recovery sleep rather than stranding button-only. Each Manual
+wake logs `manual mode: battery <mV>, gate=<0 normal/1 arm/2 stay-low>,
+paint=<0 none/1 lowbatt/2 ready>, photo=<0/1>` just before the 24-hour sleep — read
+it in the serial monitor to confirm the gate verdict and what was painted (it
+prints after the USB-Serial-JTAG re-attach, so it survives a deep-sleep wake). Actual
+throughput, power draw and panel behavior require a physical device.

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 # falls back to `git describe`, which advertises the ancient
 # pre-m4-provisioning milestone tag. Keep in sync with FW_VERSION in
 # main/defaults.h when bumping releases.
-set(PROJECT_VER "0.9.4")
+set(PROJECT_VER "0.9.5")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # Project name = public repo name; also names the app binary
 # (build/picpak-tesserae-client.bin).

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -2,6 +2,7 @@ idf_component_register(
     SRCS "main.c"
          "ble_setup.c"
          "ble_setup_protocol.c"
+         "ble_photo.c"
          "ble_wifi.c"
          "maintenance_screen.c"
          "vendor/qrcodegen.c"

--- a/firmware/main/ble_photo.c
+++ b/firmware/main/ble_photo.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "ble_photo.h"
+#include <string.h>
+static uint32_t read32(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8) | p[3];
+}
+bool ble_photo_begin(ble_photo_t *s, uint32_t id, uint32_t length,
+                     const uint8_t digest[32], uint32_t generation) {
+    if (!id || length != BLE_PHOTO_BYTES || !digest) return false;
+    *s = (ble_photo_t){.id = id, .generation = generation, .active = true};
+    memcpy(s->digest, digest, 32);
+    return true;
+}
+bool ble_photo_write(ble_photo_t *s, uint8_t *buffer, const uint8_t *packet,
+                     size_t length, uint32_t generation) {
+    if (!s->active || s->generation != generation || length <= 8 ||
+        length > 8 + BLE_PHOTO_CHUNK_BYTES || read32(packet) != s->id) return false;
+    uint32_t offset = read32(packet + 4);
+    size_t count = length - 8;
+    if (offset > s->offset || offset > BLE_PHOTO_BYTES ||
+        count > BLE_PHOTO_BYTES - offset) return false;
+    if (offset < s->offset)
+        return count <= s->offset - offset && !memcmp(buffer + offset, packet + 8, count);
+    memcpy(buffer + offset, packet + 8, count);
+    s->offset += count;
+    return true;
+}
+bool ble_photo_complete(const ble_photo_t *s, uint32_t id, uint32_t generation) {
+    return s->active && id == s->id && generation == s->generation &&
+           s->offset == BLE_PHOTO_BYTES;
+}

--- a/firmware/main/ble_photo.h
+++ b/firmware/main/ble_photo.h
@@ -1,0 +1,19 @@
+// PicPak BLE photo v1: authenticated, bounded, stop-and-wait transfers.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#define BLE_PHOTO_BYTES 30000u
+#define BLE_PHOTO_CHUNK_BYTES 192u
+typedef struct {
+    uint32_t id, offset, generation;
+    bool active;
+    uint8_t digest[32];
+} ble_photo_t;
+bool ble_photo_begin(ble_photo_t *state, uint32_t id, uint32_t length,
+                     const uint8_t digest[32], uint32_t generation);
+// Duplicate chunks are acknowledged only when their contents match.
+bool ble_photo_write(ble_photo_t *state, uint8_t *buffer, const uint8_t *packet,
+                     size_t length, uint32_t generation);
+bool ble_photo_complete(const ble_photo_t *state, uint32_t id, uint32_t generation);

--- a/firmware/main/ble_setup.c
+++ b/firmware/main/ble_setup.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "power.h"
+#include "lowbatt.h"
 #include "defaults.h"
 #include "config_store.h"
 #include "framebuf.h"
@@ -19,6 +20,9 @@
 #include "ble_setup_protocol.h"
 #include "relay_crypto.h"
 #include "ble_wifi.h"
+#include "ble_photo.h"
+#include "mbedtls/sha256.h"
+#include <math.h>
 
 #include "cJSON.h"
 #include "esp_heap_caps.h"
@@ -68,10 +72,17 @@ static const ble_uuid128_t s_qr_uuid      = TESSERAE_UUID(0x03);
 static const ble_uuid128_t s_secure_uuid  = TESSERAE_UUID(0x04);
 static const ble_uuid128_t s_event_uuid   = TESSERAE_UUID(0x05);
 
+static const ble_uuid128_t s_photo_uuid = TESSERAE_UUID(0x06);
+static const ble_uuid128_t s_photo_service_uuid = TESSERAE_UUID(0x07);
+static bool s_photo_session;
+static ble_photo_t s_photo;
+static _Atomic int64_t s_photo_activity;
+
 typedef enum { AUTH_QR = 1, AUTH_PASSKEY = 2 } auth_mode_t;
 
 typedef struct {
     auth_mode_t auth;
+    bool binary;
     uint32_t generation;
     size_t len;
     char json[BLE_SETUP_MESSAGE_MAX + 1];
@@ -84,7 +95,8 @@ typedef struct {
     bool ready;
 } staged_config_t;
 
-static ble_setup_result_t s_result;
+static _Atomic ble_setup_result_t s_result;
+static atomic_bool s_exit_on_disconnect;
 static EventGroupHandle_t s_events;
 static QueueHandle_t s_commands;
 static TaskHandle_t s_worker;
@@ -123,6 +135,7 @@ static uint8_t s_connection_nonce[BLE_SETUP_CONN_NONCE_LEN];
 static ble_setup_crypto_t s_crypto;
 static ble_setup_reassembly_t s_qr_reassembly;
 static ble_setup_reassembly_t s_native_reassembly;
+static ble_setup_reassembly_t s_photo_reassembly;
 static staged_config_t s_staged;
 static uint16_t s_out_message_id;
 static char s_info[320];
@@ -157,7 +170,7 @@ static bool prepare_connection(void)
                      (unsigned)BLE_SETUP_PROTOCOL_MAJOR, device_id, sid_hex,
                      nonce_hex, (unsigned)TESSERAE_BLE_HARDWARE_CODE,
                      TESSERAE_DEVICE_MODEL, FW_VERSION,
-                     "maintenance");
+                     s_photo_session ? "photo" : "maintenance");
     if (n <= 0 || (size_t)n >= sizeof s_info) return false;
 
     s_out_message_id = 0;
@@ -188,6 +201,12 @@ static void finish(ble_setup_result_t result)
         for (unsigned i = 0; i < 300 && atomic_load(&s_pending_events); i++) {
             if (s_conn == BLE_HS_CONN_HANDLE_NONE || s_stopping) break;
             vTaskDelay(pdMS_TO_TICKS(10));
+        }
+        if (result == BLE_SETUP_RESULT_PHOTO_RECEIVED &&
+            s_conn != BLE_HS_CONN_HANDLE_NONE) {
+            // notify_custom queues controller traffic. Allow the final receipt
+            // to leave the radio before stopping it for the panel refresh.
+            vTaskDelay(pdMS_TO_TICKS(300));
         }
     }
     s_result = result;
@@ -340,6 +359,7 @@ static void send_diagnostics(auth_mode_t auth)
     cJSON_AddBoolToObject(root, "server_configured", has_server);
     cJSON_AddStringToObject(root, "refresh_speed",
         refresh_speed_name(config_get_waveform(DEFAULT_WAVEFORM)));
+    cJSON_AddStringToObject(root, "screen_mode", config_screen_is_bluetooth() ? "bluetooth" : "wifi");
     cJSON_AddNumberToObject(root, "rssi", ble_wifi_rssi());
     if (has_wifi) cJSON_AddStringToObject(root, "ssid", ssid);
     else cJSON_AddNullToObject(root, "ssid");
@@ -469,9 +489,128 @@ static void set_refresh_speed(auth_mode_t auth, const cJSON *root)
     send_event(auth, event);
 }
 
+static bool json_u32(const cJSON *root, const char *name, uint32_t *out) {
+    const cJSON *v = cJSON_GetObjectItemCaseSensitive(root, name);
+    if (!cJSON_IsNumber(v) || !isfinite(v->valuedouble) || v->valuedouble < 0 ||
+        v->valuedouble > UINT32_MAX || floor(v->valuedouble) != v->valuedouble) return false;
+    *out = (uint32_t)v->valuedouble;
+    return true;
+}
+static void set_screen_mode(auth_mode_t auth, const cJSON *root) {
+    char value[16]; uint32_t request;
+    if (!copy_json_string(root, "value", value, sizeof value, true) ||
+        (strcmp(value, "wifi") && strcmp(value, "bluetooth")) ||
+        !json_u32(root, "request", &request)) {
+        send_simple(auth, "error", "Unsupported screen mode"); return;
+    }
+    bool bluetooth = !strcmp(value, "bluetooth");
+    uint8_t key[32] = {0}; char encoded[RELAY_B64_KEY_CAP] = {0};
+    if (bluetooth && !config_get_photo_key(key)) esp_fill_random(key, sizeof key);
+    if (bluetooth && !relay_b64url_encode(encoded, sizeof encoded, key, sizeof key)) {
+        memset(key, 0, sizeof key); send_simple(auth, "error", "Could not authorize phone"); return;
+    }
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    esp_err_t err = command_cancelled() ? ESP_FAIL : config_save_screen_mode(bluetooth, key);
+    xSemaphoreGive(s_lock);
+    memset(key, 0, sizeof key);
+    if (err != ESP_OK) { send_simple(auth, "error", "Could not save screen mode"); return; }
+    atomic_store(&s_exit_on_disconnect, true);
+    // Sent only on the physically enabled, authenticated maintenance channel.
+    char reply[192];
+    snprintf(reply, sizeof reply, "{\"event\":\"screen_mode\",\"value\":\"%s\","
+             "\"request\":%" PRIu32 ",\"photo_key\":\"%s\"}", value, request, encoded);
+    send_event(auth, reply);
+    memset(reply, 0, sizeof reply); memset(encoded, 0, sizeof encoded);
+}
+static void photo_ack(auth_mode_t auth) {
+    char reply[100];
+    snprintf(reply, sizeof reply, "{\"event\":\"photo_ack\",\"id\":%" PRIu32
+             ",\"offset\":%" PRIu32 "}", s_photo.id, s_photo.offset);
+    send_event(auth, reply);
+}
+static bool parse_digest(const char *hex, uint8_t digest[32]) {
+    if (!hex || strlen(hex) != 64) return false;
+    for (size_t i = 0; i < 32; i++) {
+        unsigned v = 0;
+        for (size_t j = 0; j < 2; j++) {
+            char c = hex[2*i+j];
+            unsigned n = c >= '0' && c <= '9' ? (unsigned)(c-'0') :
+                         c >= 'a' && c <= 'f' ? (unsigned)(c-'a'+10) : 16;
+            if (n > 15) return false;
+            v = (v << 4) | n;
+        }
+        digest[i] = (uint8_t)v;
+    }
+    return true;
+}
+static void photo_command(auth_mode_t auth, const char *op, const cJSON *root) {
+    if (auth != AUTH_QR) { send_simple(auth, "error", "Photo authorization required"); return; }
+    atomic_store(&s_photo_activity, esp_timer_get_time());
+    if (!strcmp(op, "photo_info")) {
+        // A snapshot from this wake, over the authenticated connection only.
+        // Reuse the cached pre-radio ADC reading; do not start Wi-Fi or resample
+        // while the radio loads the rail. Invalid readings are unknown, not 0 V.
+        int mv = power_battery_mv();
+        bool valid_battery = mv >= LOWBATT_MIN_PLAUSIBLE_MV && mv <= 5000;
+        char battery[80];
+        if (valid_battery)
+            snprintf(battery, sizeof battery, "\"battery_mv\":%d,\"low_battery\":%s",
+                     mv, mv < LOWBATT_ARM_MV ? "true" : "false");
+        else
+            snprintf(battery, sizeof battery, "\"battery_mv\":null,\"low_battery\":null");
+        char reply[320];
+        snprintf(reply, sizeof reply,
+                 "{\"event\":\"photo_info\",\"version\":1,\"width\":400,"
+                 "\"height\":300,\"bytes\":30000,\"chunk_bytes\":192,"
+                 "\"format\":\"picpak-bwry2-bottom-up\",%s,"
+                 "\"refresh_speed\":\"%s\",\"screen_mode\":\"%s\"}",
+                 battery, refresh_speed_name(config_get_waveform(DEFAULT_WAVEFORM)),
+                 config_screen_is_bluetooth() ? "bluetooth" : "wifi");
+        send_event(auth, reply);
+    } else if (!strcmp(op, "photo_begin")) {
+        uint32_t id, length; char hex[65], format[32]; uint8_t digest[32];
+        if (!json_u32(root, "id", &id) || !json_u32(root, "bytes", &length) ||
+            !copy_json_string(root, "sha256", hex, sizeof hex, true) || !parse_digest(hex, digest) ||
+            !copy_json_string(root, "format", format, sizeof format, true) ||
+            strcmp(format, "picpak-bwry2-bottom-up") ||
+            !ble_photo_begin(&s_photo, id, length, digest, s_command_generation)) {
+            send_simple(auth, "error", "Unsupported photo format or size"); return;
+        }
+        photo_ack(auth);
+    } else if (!strcmp(op, "photo_end")) {
+        uint32_t id; uint8_t digest[32];
+        if (!json_u32(root, "id", &id) || !ble_photo_complete(&s_photo, id, s_command_generation) ||
+            mbedtls_sha256(framebuf(), BLE_PHOTO_BYTES, digest, 0) != 0 ||
+            memcmp(digest, s_photo.digest, 32) != 0) {
+            send_simple(auth, "error", "Incomplete photo or checksum mismatch"); return;
+        }
+        if (command_cancelled()) return;
+        char reply[100];
+        snprintf(reply, sizeof reply, "{\"event\":\"photo_received\",\"id\":%" PRIu32 "}", id);
+        send_event(auth, reply);
+        finish(BLE_SETUP_RESULT_PHOTO_RECEIVED);
+    } else if (!strcmp(op, "photo_cancel")) {
+        memset(&s_photo, 0, sizeof s_photo);
+        send_simple(auth, "photo_cancelled", NULL);
+        finish(BLE_SETUP_RESULT_CANCELLED);
+    } else send_simple(auth, "error", "Operation unavailable in photo mode");
+}
+static void photo_data(const command_t *command) {
+    if (!s_photo_session || command->auth != AUTH_QR) {
+        send_simple(command->auth, "error", "Photo session required"); return;
+    }
+    if (!ble_photo_write(&s_photo, framebuf(), (const uint8_t *)command->json,
+                         command->len, s_command_generation)) {
+        send_simple(command->auth, "error", "Invalid photo chunk"); return;
+    }
+    atomic_store(&s_photo_activity, esp_timer_get_time());
+    photo_ack(command->auth);
+}
+
 static void process_command(const command_t *command)
 {
     if (command_cancelled()) return;
+    if (command->binary) { photo_data(command); return; }
     cJSON *root = cJSON_ParseWithLength(command->json, command->len);
     if (!root) { send_simple(command->auth, "error", "Invalid command JSON"); return; }
     const cJSON *op = cJSON_GetObjectItemCaseSensitive(root, "op");
@@ -480,8 +619,11 @@ static void process_command(const command_t *command)
         send_simple(command->auth, "error", "Missing operation");
         return;
     }
+    if (!s_photo_session && config_screen_is_bluetooth()) atomic_store(&s_exit_on_disconnect, true);
     ESP_LOGI(TAG, "command: %s", op->valuestring);
-    if (strcmp(op->valuestring, "scan") == 0) run_scan(command->auth);
+    if (s_photo_session) photo_command(command->auth, op->valuestring, root);
+    else if (strcmp(op->valuestring, "set_screen_mode") == 0) set_screen_mode(command->auth, root);
+    else if (strcmp(op->valuestring, "scan") == 0) run_scan(command->auth);
     else if (strcmp(op->valuestring, "stage") == 0) stage_config(command->auth, root);
     else if (strcmp(op->valuestring, "apply") == 0) apply_config(command->auth);
     else if (strcmp(op->valuestring, "diagnostics") == 0) send_diagnostics(command->auth);
@@ -534,7 +676,7 @@ static void worker_task(void *arg)
     vTaskDelete(NULL);
 }
 
-static int accept_frame(auth_mode_t auth, struct os_mbuf *om)
+static int accept_frame(auth_mode_t auth, struct os_mbuf *om, bool binary)
 {
     size_t frame_len = OS_MBUF_PKTLEN(om);
     uint8_t frame[BLE_SETUP_MESSAGE_MAX + 32];
@@ -548,7 +690,7 @@ static int accept_frame(auth_mode_t auth, struct os_mbuf *om)
         if (!ble_setup_open(&s_crypto, BLE_SETUP_DIR_APP_TO_DEVICE,
                             frame, frame_len, plain, sizeof plain, &plain_len))
             return BLE_ATT_ERR_INSUFFICIENT_AUTHEN;
-        reassembly = &s_qr_reassembly;
+        reassembly = binary ? &s_photo_reassembly : &s_qr_reassembly;
     } else {
         if (frame[0] != BLE_SETUP_FRAME_NATIVE || frame_len < 2)
             return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -564,7 +706,7 @@ static int accept_frame(auth_mode_t auth, struct os_mbuf *om)
     bool complete = ble_setup_reassembly_push(reassembly, &chunk, &valid);
     if (!valid) return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
     if (complete) {
-        command_t command = { .auth = auth, .generation = atomic_load(&s_generation), .len = reassembly->len };
+        command_t command = { .auth = auth, .binary = binary, .generation = atomic_load(&s_generation), .len = reassembly->len };
         memcpy(command.json, reassembly->bytes, reassembly->len + 1);
         ble_setup_reassembly_reset(reassembly);
         if (xQueueSend(s_commands, &command, 0) != pdTRUE)
@@ -591,19 +733,19 @@ static int gatt_access(uint16_t conn_handle, uint16_t attr_handle,
         int rc = os_mbuf_append(ctxt->om, s_last_event, s_last_event_len);
         return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
     }
-    if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR && which == 2) {
+    if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR && (which == 2 || which == 5)) {
         xSemaphoreTake(s_lock, portMAX_DELAY);
-        int rc = accept_frame(AUTH_QR, ctxt->om);
+        int rc = accept_frame(AUTH_QR, ctxt->om, which == 5);
         xSemaphoreGive(s_lock);
         return rc;
     }
-    if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR && which == 3)
-        return accept_frame(AUTH_PASSKEY, ctxt->om);
+    if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR && which == 3 && !s_photo_session)
+        return accept_frame(AUTH_PASSKEY, ctxt->om, false);
     (void)conn_handle; (void)attr_handle;
     return BLE_ATT_ERR_UNLIKELY;
 }
 
-static const struct ble_gatt_svc_def s_services[] = {{
+static struct ble_gatt_svc_def s_services[] = {{
     .type = BLE_GATT_SVC_TYPE_PRIMARY,
     .uuid = &s_service_uuid.u,
     .characteristics = (struct ble_gatt_chr_def[]) {{
@@ -620,6 +762,9 @@ static const struct ble_gatt_svc_def s_services[] = {{
         .uuid = &s_event_uuid.u, .access_cb = gatt_access, .arg = (void *)4,
         .val_handle = &s_event_handle,
         .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
+    }, {
+        .uuid = &s_photo_uuid.u, .access_cb = gatt_access, .arg = (void *)5,
+        .flags = BLE_GATT_CHR_F_WRITE,
     }, {0}}
 }, {0}};
 
@@ -629,9 +774,10 @@ static void advertise(void)
      * the 31-byte legacy advertisement without moving identity into the scan
      * response. See docs/ble-setup-protocol.md. */
     uint8_t service_data[26];
-    memcpy(service_data, s_service_uuid.value, 16);
+    const ble_uuid128_t *service = s_photo_session ? &s_photo_service_uuid : &s_service_uuid;
+    memcpy(service_data, service->value, 16);
     service_data[16] = BLE_SETUP_PROTOCOL_MAJOR;
-    service_data[17] = 0x02;
+    service_data[17] = s_photo_session ? 0x04 : 0x02;
     service_data[18] = TESSERAE_BLE_HARDWARE_CODE;
     uint8_t mac[6] = {0}; esp_read_mac(mac, ESP_MAC_WIFI_STA);
     memcpy(service_data + 19, mac + 3, 3);
@@ -650,7 +796,7 @@ static void advertise(void)
     char name[16];
     snprintf(name, sizeof name, "Tes-%02X%02X%02X", mac[3], mac[4], mac[5]);
     struct ble_hs_adv_fields response = {0};
-    response.uuids128 = &s_service_uuid;
+    response.uuids128 = service;
     response.num_uuids128 = 1;
     response.uuids128_is_complete = 1;
     response.name = (const uint8_t *)name;
@@ -662,6 +808,7 @@ static void advertise(void)
     struct ble_gap_adv_params params = {0};
     params.conn_mode = BLE_GAP_CONN_MODE_UND;
     params.disc_mode = BLE_GAP_DISC_MODE_GEN;
+    if (s_photo_session) { params.itvl_min = 160; params.itvl_max = 240; } // 100-150 ms
     rc = ble_gap_adv_start(s_addr_type, NULL, BLE_HS_FOREVER, &params, gap_event, NULL);
     if (rc != 0) ESP_LOGE(TAG, "advertise failed: %d", rc);
 }
@@ -733,7 +880,11 @@ static int gap_event(struct ble_gap_event *event, void *arg)
         ble_setup_reassembly_reset(&s_qr_reassembly);
         ble_setup_reassembly_reset(&s_native_reassembly);
         xSemaphoreGive(s_lock);
-        if (!s_stopping) advertise();
+        if (s_photo_session) {
+            if (s_result != BLE_SETUP_RESULT_PHOTO_RECEIVED) finish(BLE_SETUP_RESULT_CANCELLED);
+        } else if (atomic_load(&s_exit_on_disconnect)) {
+            finish(BLE_SETUP_RESULT_REBOOT);
+        } else if (!s_stopping) advertise();
         return 0;
     case BLE_GAP_EVENT_SUBSCRIBE:
         if (event->subscribe.attr_handle == s_event_handle)
@@ -753,7 +904,9 @@ static int gap_event(struct ble_gap_event *event, void *arg)
 
 static bool prepare_session(void)
 {
-    esp_fill_random(s_secret, sizeof s_secret);
+    if (s_photo_session) {
+        if (!config_get_photo_key(s_secret)) return false;
+    } else esp_fill_random(s_secret, sizeof s_secret);
     esp_fill_random(s_sid, sizeof s_sid);
     s_passkey = 100000u + esp_random() % 900000u;
     char key[RELAY_B64_KEY_CAP];
@@ -785,6 +938,7 @@ static bool start_ble(void)
     ble_hs_cfg.sm_sc = 1;
     ble_svc_gap_init();
     ble_svc_gatt_init();
+    s_services[0].uuid = s_photo_session ? &s_photo_service_uuid.u : &s_service_uuid.u;
     if (ble_gatts_count_cfg(s_services) != 0 || ble_gatts_add_svcs(s_services) != 0) {
         return false; // caller owns complete callout/controller cleanup
     }
@@ -881,8 +1035,13 @@ static void scrub_session(void)
     memset(s_logs, 0, sizeof s_logs);
 }
 
-ble_setup_result_t ble_setup_run(uint32_t timeout_s)
+static ble_setup_result_t run_session(uint32_t timeout_s, bool photo)
 {
+    s_photo_session = photo;
+    atomic_store(&s_exit_on_disconnect, false);
+    memset(&s_photo, 0, sizeof s_photo);
+    atomic_store(&s_photo_activity, 0);
+    ble_setup_reassembly_reset(&s_photo_reassembly);
     bool button_exit = false;
     s_result = BLE_SETUP_RESULT_TIMEOUT;
     s_stopping = false; s_notify = false; s_conn = BLE_HS_CONN_HANDLE_NONE;
@@ -903,18 +1062,20 @@ ble_setup_result_t ble_setup_run(uint32_t timeout_s)
         scrub_session();
         return BLE_SETUP_RESULT_ERROR;
     }
-    add_log("BLE maintenance started");
+    add_log(photo ? "BLE photo session started" : "BLE maintenance started");
 
     // Finish the panel refresh before advertising: the QR must match this session,
     // and display/radio peaks should not overlap on PicPak's marginal supply.
-    if (!maintenance_screen_render(framebuf(), s_qr_payload, s_passkey) ||
-        epd_init() != ESP_OK) {
-        scrub_session();
-        return BLE_SETUP_RESULT_ERROR;
+    if (!photo) {
+        if (!maintenance_screen_render(framebuf(), s_qr_payload, s_passkey) ||
+            epd_init() != ESP_OK) {
+            scrub_session();
+            return BLE_SETUP_RESULT_ERROR;
+        }
+        config_clear_frame_ref();
+        epd_display(framebuf());
+        epd_sleep();
     }
-    config_clear_frame_ref();
-    epd_display(framebuf());
-    epd_sleep();
 
     if (xTaskCreate(worker_task, "ble_setup_work", 7168, NULL, 5, &s_worker) != pdPASS ||
         !start_ble()) {
@@ -927,7 +1088,11 @@ ble_setup_result_t ble_setup_run(uint32_t timeout_s)
     int64_t deadline = started + (int64_t)timeout_s * 1000000;
     maintenance_button_t button = maintenance_button_init(
         power_button_held(), (uint32_t)(started / 1000));
-    while (esp_timer_get_time() < deadline) {
+    while (true) {
+        int64_t now = esp_timer_get_time();
+        int64_t activity = atomic_load(&s_photo_activity);
+        int64_t expires = photo && activity ? activity + 300000000LL : deadline;
+        if (now >= expires || (photo && now - started >= 600000000LL)) break;
         EventBits_t bits = xEventGroupWaitBits(s_events, BIT_DONE, pdFALSE, pdTRUE,
                                                pdMS_TO_TICKS(20));
         if (bits & BIT_DONE) break;
@@ -942,14 +1107,30 @@ cleanup:
     stop_ble();
     // The worker has stopped before assigning the local cancellation result.
     // Already committed settings remain saved; pending commands are discarded.
-    if (button_exit) s_result = BLE_SETUP_RESULT_CANCELLED;
+    if (button_exit && s_result != BLE_SETUP_RESULT_PHOTO_RECEIVED)
+        s_result = BLE_SETUP_RESULT_CANCELLED;
     ble_wifi_stop();
     scrub_session();
-    if (s_result == BLE_SETUP_RESULT_TIMEOUT || s_result == BLE_SETUP_RESULT_ERROR ||
-        s_result == BLE_SETUP_RESULT_REBOOT || s_result == BLE_SETUP_RESULT_CANCELLED) {
+    if (!photo && (s_result == BLE_SETUP_RESULT_TIMEOUT || s_result == BLE_SETUP_RESULT_ERROR ||
+        s_result == BLE_SETUP_RESULT_REBOOT || s_result == BLE_SETUP_RESULT_CANCELLED)) {
         // Do not leave an expired QR on the screen if the server is offline.
-        maintenance_screen_closed(framebuf());
+        // Closing diagnostics keeps the saved screen mode. In manual mode,
+        // explain how to wake photo reception instead of implying it was disabled.
+        if (config_screen_is_bluetooth()) maintenance_screen_photo_ready(framebuf());
+        else maintenance_screen_closed(framebuf());
         if (epd_init() == ESP_OK) { epd_display(framebuf()); epd_sleep(); }
     }
+    if (photo && s_result == BLE_SETUP_RESULT_PHOTO_RECEIVED) {
+        // Radio off before the high-current refresh. The receipt explicitly
+        // confirms verified reception, not successful physical refresh.
+        config_clear_frame_ref();
+        if (epd_init() == ESP_OK) { epd_display(framebuf()); epd_sleep(); }
+        else s_result = BLE_SETUP_RESULT_ERROR;
+    }
+    if (photo) memset(framebuf(), 0, BLE_PHOTO_BYTES);
+    memset(&s_photo, 0, sizeof s_photo);
+    ble_setup_reassembly_reset(&s_photo_reassembly);
     return s_result;
 }
+ble_setup_result_t ble_setup_run(uint32_t timeout_s) { return run_session(timeout_s, false); }
+ble_setup_result_t ble_photo_run(uint32_t timeout_s) { return run_session(timeout_s, true); }

--- a/firmware/main/ble_setup.h
+++ b/firmware/main/ble_setup.h
@@ -11,9 +11,13 @@ typedef enum {
     BLE_SETUP_RESULT_FACTORY_RESET,
     BLE_SETUP_RESULT_ERROR,
     BLE_SETUP_RESULT_CANCELLED,
+    BLE_SETUP_RESULT_PHOTO_RECEIVED,
 } ble_setup_result_t;
 
 /* Starts advertising, paints the QR/passkey screen, and serves one bounded
  * session. Wi-Fi changes are saved only after joining successfully; server
  * settings are preserved even when the server is unreachable. */
 ble_setup_result_t ble_setup_run(uint32_t timeout_s);
+
+// Photo sessions preserve the current picture until a complete verified upload.
+ble_setup_result_t ble_photo_run(uint32_t timeout_s);

--- a/firmware/main/config_store.c
+++ b/firmware/main/config_store.c
@@ -219,6 +219,43 @@ uint8_t config_get_waveform(uint8_t fallback) {
     nvs_close(h);
     return v <= 2 ? v : fallback;
 }
+static bool read_photo_config(uint8_t value[33]) {
+    nvs_handle_t h;
+    if (nvs_open(NS_STATE, NVS_READONLY, &h) != ESP_OK) return false;
+    size_t len = 33;
+    esp_err_t err = nvs_get_blob(h, "photo_config", value, &len);
+    nvs_close(h);
+    return err == ESP_OK && len == 33 && value[0] == 1;
+}
+bool config_screen_is_bluetooth(void) {
+    uint8_t value[33] = {0};
+    bool result = read_photo_config(value);
+    memset(value, 0, sizeof value);
+    return result;
+}
+bool config_get_photo_key(uint8_t key[32]) {
+    uint8_t value[33] = {0};
+    bool result = read_photo_config(value);
+    if (result) memcpy(key, value + 1, 32);
+    memset(value, 0, sizeof value);
+    return result;
+}
+esp_err_t config_save_screen_mode(bool bluetooth, const uint8_t key[32]) {
+    if (bluetooth && !key) return ESP_ERR_INVALID_ARG;
+    uint8_t value[33] = {0};
+    value[0] = bluetooth ? 1 : 0;
+    if (bluetooth) memcpy(value + 1, key, 32);
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NS_STATE, NVS_READWRITE, &h);
+    if (err == ESP_OK) {
+        err = nvs_set_blob(h, "photo_config", value, sizeof value);
+        if (err == ESP_OK) err = nvs_commit(h);
+        nvs_close(h);
+    }
+    memset(value, 0, sizeof value);
+    return err;
+}
+
 void config_set_paired_pending(bool pending) {
     nvs_handle_t h;
     if (nvs_open(NS_STATE, NVS_READWRITE, &h) != ESP_OK) return;

--- a/firmware/main/config_store.h
+++ b/firmware/main/config_store.h
@@ -39,6 +39,12 @@ bool config_get_ap_hint(uint8_t bssid[6], uint8_t *chan);
 void config_set_ap_hint(const uint8_t bssid[6], uint8_t chan);
 void config_clear_ap_hint(void);
 
+// Display source is independent of the REST/MQTT/relay transport.
+// A single committed blob stores mode + the 32-byte photo authorization key.
+bool config_screen_is_bluetooth(void);
+bool config_get_photo_key(uint8_t key[32]);
+esp_err_t config_save_screen_mode(bool bluetooth, const uint8_t key[32]);
+
 // --- portal write path ---
 void config_set_wifi(const char *ssid, const char *pass);   // blank/NULL pass keeps existing
 void config_set_server_url(const char *url);

--- a/firmware/main/defaults.h
+++ b/firmware/main/defaults.h
@@ -29,7 +29,7 @@
 #endif
 
 #ifndef FW_VERSION
-#define FW_VERSION          "0.9.4"
+#define FW_VERSION          "0.9.5"
 #endif
 #define DEVICE_KIND         "picpak_client"
 

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -87,6 +87,7 @@ void app_main(void) {
         if (is_power_fault_reset(reason) ||
             lowbatt_gate(power_battery_mv(), false) != LOWBATT_NORMAL) {
             splash_show_lowbatt();
+            if (config_screen_is_bluetooth()) power_sleep_until_button();
             power_deep_sleep(lowbatt_wake_s());
         }
         ble_setup_run(BLE_MAINTENANCE_TIMEOUT_S);
@@ -94,6 +95,17 @@ void app_main(void) {
         // Clear Wi-Fi requests persist a one-shot BLE recovery flag; timeout
         // then falls back to the original AP setup if credentials are still absent.
         esp_restart();
+    }
+    // Manual mode is decided before Wi-Fi credential / AP fallback handling.
+    if (config_screen_is_bluetooth() && gesture != BTN_GESTURE_PROVISION) {
+        bool button_wake = esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_GPIO;
+        if (button_wake || gesture == BTN_GESTURE_TAP || gesture == BTN_GESTURE_REFRESH) {
+            power_measure_battery();
+            if (!is_power_fault_reset(reason) &&
+                lowbatt_gate(power_battery_mv(), false) == LOWBATT_NORMAL)
+                ble_photo_run(90);
+        }
+        power_sleep_until_button();
     }
     bool want_provision = (gesture == BTN_GESTURE_PROVISION);
     bool want_refresh   = (gesture == BTN_GESTURE_REFRESH);
@@ -110,13 +122,16 @@ void app_main(void) {
     if (want_provision && gesture == BTN_GESTURE_PROVISION && lowbatt_locked()) {
         ESP_LOGW(TAG, "provision gesture ignored: battery locked, charge first");
         splash_show_lowbatt();
+        if (config_screen_is_bluetooth()) power_sleep_until_button();
         power_deep_sleep(lowbatt_wake_s());            // no return
     }
     if (want_provision) {
         splash_show_setup();                           // panel shows AP name/password while you provision
         if (provisioning_run_blocking(NULL) == ESP_OK) {
+            ESP_ERROR_CHECK(config_save_screen_mode(false, NULL));
             esp_restart();                             // saved -> re-enter normal path with new creds
         }
+        if (config_screen_is_bluetooth()) power_sleep_until_button();
         power_deep_sleep(SLEEP_INTERVAL_DEFAULT_S);   // timeout: sleep, retry portal next wake
     }
 

--- a/firmware/main/main.c
+++ b/firmware/main/main.c
@@ -14,6 +14,9 @@
 #include "provisioning.h"
 #include "splash.h"
 #include "lowbatt.h"
+#include "manual_core.h"
+#include "maintenance_screen.h"
+#include "framebuf.h"
 #include "led.h"
 
 #include <time.h>
@@ -96,16 +99,41 @@ void app_main(void) {
         // then falls back to the original AP setup if credentials are still absent.
         esp_restart();
     }
-    // Manual mode is decided before Wi-Fi credential / AP fallback handling.
+    // Manual (Bluetooth) mode is decided before Wi-Fi credential / AP fallback handling.
+    // Unlike the Wi-Fi path there is no server to re-fetch content from, so the low-battery
+    // gate must give its own feedback: paint the charge splash when the cell goes low, and
+    // clear it to a "ready" screen once it recovers. Wakes are either a button press (a user
+    // is present -> advertise for a photo) or a 24 h low-power poll (battery re-check only, so
+    // an untouched device still learns it needs charging). A brownout is deferred first,
+    // before the gate runs, so a weak cell settles instead of stranding button-only forever.
     if (config_screen_is_bluetooth() && gesture != BTN_GESTURE_PROVISION) {
-        bool button_wake = esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_GPIO;
-        if (button_wake || gesture == BTN_GESTURE_TAP || gesture == BTN_GESTURE_REFRESH) {
-            power_measure_battery();
-            if (!is_power_fault_reset(reason) &&
-                lowbatt_gate(power_battery_mv(), false) == LOWBATT_NORMAL)
-                ble_photo_run(90);
+        if (is_power_fault_reset(reason)) {
+            ESP_LOGW(TAG, "manual mode: power-fault wake (reason=%d): deferring %d s",
+                     (int)reason, BROWNOUT_RECOVERY_SLEEP_S);
+            power_deep_sleep(BROWNOUT_RECOVERY_SLEEP_S);   // no return
         }
-        power_sleep_until_button();
+        bool user_wake = esp_sleep_get_wakeup_cause() == ESP_SLEEP_WAKEUP_GPIO ||
+                         gesture == BTN_GESTURE_TAP || gesture == BTN_GESTURE_REFRESH;
+        power_measure_battery();
+        bool was_locked = lowbatt_locked();               // read before the gate mutates state
+        lowbatt_action_t gate = lowbatt_gate(power_battery_mv(), false);
+        manual_decision_t act = manual_decide(user_wake, gate, was_locked);
+
+        if (act.paint == MANUAL_PAINT_LOWBATT) {
+            ESP_LOGW(TAG, "manual mode: battery low -> charge splash + %lu s poll",
+                     (unsigned long)lowbatt_wake_s());
+            splash_show_lowbatt();
+        } else if (act.paint == MANUAL_PAINT_READY) {
+            ESP_LOGI(TAG, "manual mode: battery recovered -> ready screen");
+            maintenance_screen_photo_ready(framebuf());
+            if (epd_init() == ESP_OK) { epd_display(framebuf()); epd_sleep(); }
+        }
+        if (act.run_photo) ble_photo_run(90);
+        // Diagnostic summary, printed after the session so it survives the USB-Serial-JTAG
+        // re-attach that swallows the early-boot battery log on a deep-sleep wake.
+        ESP_LOGI(TAG, "manual mode: battery %d mV, gate=%d, paint=%d, photo=%d",
+                 power_battery_mv(), (int)gate, (int)act.paint, (int)act.run_photo);
+        power_deep_sleep(lowbatt_wake_s());                // 24 h poll + button wake; no return
     }
     bool want_provision = (gesture == BTN_GESTURE_PROVISION);
     bool want_refresh   = (gesture == BTN_GESTURE_REFRESH);

--- a/firmware/main/maintenance_screen.c
+++ b/firmware/main/maintenance_screen.c
@@ -35,6 +35,33 @@ void maintenance_screen_closed(uint8_t *fb) {
     text(fb, 24, 208, "next image when Wi-Fi returns.", 1);
 }
 
+static void photo_guide_step(uint8_t *fb, int y, const char *number, const char *label) {
+    // One text size and a fixed baseline for every step; the outline keeps
+    // the sequence distinct without adding another type scale or colour.
+    const int cx = 48, cy = y + 8;
+    for (int dy = -16; dy <= 16; dy++)
+        for (int dx = -16; dx <= 16; dx++) {
+            int distance = dx * dx + dy * dy;
+            if (distance >= 14 * 14 && distance <= 16 * 16)
+                pixel(fb, cx + dx, cy + dy);
+        }
+    text(fb, cx - 8, y, number, 2);
+    text(fb, 80, y, label, 2);
+}
+
+void maintenance_screen_photo_ready(uint8_t *fb) {
+    fb_fill(fb, 1);
+    text(fb, 32, 32, "Bluetooth photos", 2);
+    for (int x = 32; x < EPD_W - 32; x++) {
+        pixel(fb, x, 70);
+        pixel(fb, x, 246);
+    }
+    photo_guide_step(fb, 98, "1", "Open Tesserae");
+    photo_guide_step(fb, 148, "2", "Press button once");
+    photo_guide_step(fb, 198, "3", "Tap Send in app");
+    text(fb, 32, 266, "Hold 10 seconds for maintenance", 1);
+}
+
 bool maintenance_screen_render(uint8_t *fb, const char *payload, uint32_t passkey) {
     if (!fb || !payload || passkey > 999999) return false;
     uint8_t qr[qrcodegen_BUFFER_LEN_FOR_VERSION(10)];

--- a/firmware/main/maintenance_screen.h
+++ b/firmware/main/maintenance_screen.h
@@ -6,3 +6,4 @@
 // Render into the existing 400x300 bottom-up packed BWRY framebuffer.
 bool maintenance_screen_render(uint8_t *fb, const char *qr_payload, uint32_t passkey);
 void maintenance_screen_closed(uint8_t *fb);
+void maintenance_screen_photo_ready(uint8_t *fb);

--- a/firmware/main/manual_core.h
+++ b/firmware/main/manual_core.h
@@ -1,0 +1,45 @@
+// manual_core.h — pure Manual (Bluetooth) photo-mode wake decision (host-testable).
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 varanu5 <https://github.com/varanu5>
+//
+// One decision per wake in Manual mode, given the low-battery gate's verdict and the wake
+// context. Manual mode wakes on a button press (user present) or a 24 h low-power poll
+// (battery check only). This decides what to paint and whether to bring up the BLE radio;
+// the caller always re-arms the 24 h poll afterward (a brownout reset is deferred earlier,
+// before the gate runs, so it never reaches here). Pure: no hardware, no NVS, unit-testable.
+#pragma once
+#include <stdbool.h>
+#include "lowbatt_core.h"
+
+typedef enum {
+    MANUAL_PAINT_NONE = 0,   // leave the panel as-is
+    MANUAL_PAINT_LOWBATT,    // paint the "battery low — charge" splash (just went low)
+    MANUAL_PAINT_READY,      // paint the "ready for photos" screen (just recovered)
+} manual_paint_t;
+
+typedef struct {
+    manual_paint_t paint;    // what to repaint before sleeping
+    bool           run_photo;// bring up BLE and advertise for a photo transfer
+} manual_decision_t;
+
+// Decide the Manual-mode action for this wake. Pure: no side effects.
+//   user_wake   a button/tap/refresh wake (a human is present), vs. the 24 h poll timer.
+//   gate        the low-battery gate's verdict for this wake (NORMAL / ARM / STAY_LOW).
+//   was_locked  whether the low-battery lock was set BEFORE the gate ran (to detect recovery).
+static inline manual_decision_t manual_decide(bool user_wake, lowbatt_action_t gate,
+                                              bool was_locked) {
+    manual_decision_t d = { MANUAL_PAINT_NONE, false };
+    switch (gate) {
+        case LOWBATT_ARM:
+            d.paint = MANUAL_PAINT_LOWBATT;   // just went low: warn once, never run the radio
+            break;
+        case LOWBATT_STAY_LOW:
+            break;                             // still low: keep polling, no repaint, no radio
+        case LOWBATT_NORMAL:
+        default:
+            if (was_locked) d.paint = MANUAL_PAINT_READY;   // recovered: clear the charge splash
+            if (user_wake)  d.run_photo = true;             // a human is here: advertise for a photo
+            break;
+    }
+    return d;
+}

--- a/firmware/main/power.c
+++ b/firmware/main/power.c
@@ -137,8 +137,8 @@ btn_gesture_t power_boot_gesture(void) {
     return BTN_GESTURE_TAP;
 }
 
-void power_deep_sleep(uint32_t seconds) {
-    if (seconds < SLEEP_INTERVAL_MIN_S) seconds = SLEEP_INTERVAL_MIN_S;
+static void enter_deep_sleep(uint32_t seconds) {
+    // Zero is the manual photo mode: GPIO wake only, no periodic radio work.
     if (seconds > SLEEP_INTERVAL_MAX_S) seconds = SLEEP_INTERVAL_MAX_S;
 
     // The wake button (GPIO2) is shared with the battery ADC. A battery read
@@ -153,7 +153,14 @@ void power_deep_sleep(uint32_t seconds) {
     }
 
     ESP_LOGI(TAG, "deep sleep %u s (button wake armed)", (unsigned)seconds);
-    esp_sleep_enable_timer_wakeup((uint64_t)seconds * 1000000ULL);
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+    if (seconds) esp_sleep_enable_timer_wakeup((uint64_t)seconds * 1000000ULL);
     esp_deep_sleep_enable_gpio_wakeup(1ULL << PIN_BTN, ESP_GPIO_WAKEUP_GPIO_LOW);
     esp_deep_sleep_start();
+}
+
+void power_sleep_until_button(void) { enter_deep_sleep(0); }
+void power_deep_sleep(uint32_t seconds) {
+    if (seconds < SLEEP_INTERVAL_MIN_S) seconds = SLEEP_INTERVAL_MIN_S;
+    enter_deep_sleep(seconds);
 }

--- a/firmware/main/power.h
+++ b/firmware/main/power.h
@@ -15,8 +15,9 @@ bool power_button_held(void);  // GPIO2 currently pressed (active-low)
 // Boot button-hold gesture, classified on RELEASE (see thresholds in defaults.h).
 // Run the boot-hold window: block while the button is held at boot (keeping USB
 // enumerated for re-flashing), then classify the gesture by how long it was held.
-// A held-to-20s returns PROVISION; released 5-20s returns REFRESH; released
-// 3-5s returns MAINTENANCE; shorter returns TAP; not held at boot returns NONE.
+// A held-to-20s returns PROVISION; released 10-20s returns MAINTENANCE; released
+// 5-10s returns REFRESH; shorter returns TAP; not held at boot returns NONE.
 btn_gesture_t power_boot_gesture(void);
 
+void power_sleep_until_button(void);
 void power_deep_sleep(uint32_t seconds);   // timer + button wake, then sleep (no return)

--- a/firmware/test/test_ble_photo.c
+++ b/firmware/test/test_ble_photo.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "ble_photo.h"
+static void put32(uint8_t *p, uint32_t v) {
+    p[0]=v>>24; p[1]=v>>16; p[2]=v>>8; p[3]=v;
+}
+int main(void) {
+    ble_photo_t s = {0}; uint8_t buffer[BLE_PHOTO_BYTES] = {0}, digest[32] = {1};
+    uint8_t packet[8 + BLE_PHOTO_CHUNK_BYTES] = {0};
+    assert(!ble_photo_begin(&s, 0, BLE_PHOTO_BYTES, digest, 7));
+    assert(!ble_photo_begin(&s, 1, BLE_PHOTO_BYTES+1, digest, 7));
+    assert(ble_photo_begin(&s, 0x01020304, BLE_PHOTO_BYTES, digest, 7));
+    put32(packet, s.id); put32(packet+4, 1);
+    assert(!ble_photo_write(&s, buffer, packet, sizeof packet, 7)); // missing first byte
+    put32(packet+4, 0);
+    assert(!ble_photo_write(&s, buffer, packet, sizeof packet, 8)); // new connection
+    assert(!ble_photo_write(&s, buffer, packet, 8, 7));
+    memset(packet+8, 0x1b, BLE_PHOTO_CHUNK_BYTES); // B/W/Y/R packed vector
+    assert(ble_photo_write(&s, buffer, packet, sizeof packet, 7));
+    assert(s.offset == 192 && buffer[0] == 0x1b);
+    assert(ble_photo_write(&s, buffer, packet, sizeof packet, 7)); // lost ACK retry
+    assert(s.offset == 192);
+    packet[8] ^= 1;
+    assert(!ble_photo_write(&s, buffer, packet, sizeof packet, 7)); // changed duplicate
+    packet[8] ^= 1;
+    assert(!ble_photo_complete(&s, s.id, 7));
+    while (s.offset < BLE_PHOTO_BYTES) {
+        put32(packet+4, s.offset);
+        size_t count = BLE_PHOTO_BYTES-s.offset;
+        if (count > BLE_PHOTO_CHUNK_BYTES) count = BLE_PHOTO_CHUNK_BYTES;
+        assert(ble_photo_write(&s, buffer, packet, 8+count, 7));
+    }
+    assert(ble_photo_complete(&s, 0x01020304, 7));
+    assert(!ble_photo_complete(&s, s.id, 8));
+    assert(!ble_photo_complete(&s, 1, 7));
+    put32(packet+4, UINT32_MAX);
+    assert(!ble_photo_write(&s, buffer, packet, sizeof packet, 7));
+    put32(packet+4, BLE_PHOTO_BYTES);
+    assert(!ble_photo_write(&s, buffer, packet, sizeof packet, 7));
+    puts("BLE photo: bounds, ordering, duplicates, full frame and connection isolation passed");
+}

--- a/firmware/test/test_maintenance_store.c
+++ b/firmware/test/test_maintenance_store.c
@@ -59,6 +59,17 @@ esp_err_t nvs_get_u32(nvs_handle_t h, const char *k, uint32_t *v) { size_t n = s
 int main(void) {
     char ssid[33], pass[65], url[128], token[64];
     assert(config_init() == ESP_OK);
+    uint8_t photo_key[32], read_key[32]; memset(photo_key, 0x5a, sizeof photo_key);
+    assert(!config_screen_is_bluetooth());
+    assert(!config_get_photo_key(read_key));
+    assert(config_save_screen_mode(true, NULL) == ESP_ERR_INVALID_ARG);
+    fail_commit = 1;
+    assert(config_save_screen_mode(true, photo_key) == ESP_FAIL);
+    fail_commit = 0;
+    assert(config_save_screen_mode(true, photo_key) == ESP_OK);
+    assert(config_screen_is_bluetooth());
+    assert(config_get_photo_key(read_key) && !memcmp(photo_key, read_key, 32));
+
     config_set_server_url("http://example.test:8000");
     config_set_device_token("test-token");
     config_set_transport(0);
@@ -77,6 +88,8 @@ int main(void) {
     assert(config_save_waveform(0) == ESP_OK);
     assert(config_clear_wifi() == ESP_OK);
     assert(!config_get_wifi(ssid, sizeof ssid, pass, sizeof pass));
+    assert(config_screen_is_bluetooth()); // clearing Wi-Fi preserves manual mode
+    assert(config_get_photo_key(read_key) && !memcmp(photo_key, read_key, 32));
     assert(config_take_ble_recovery());
     assert(!config_take_ble_recovery());
     assert(config_get_waveform(2) == 0);
@@ -93,7 +106,11 @@ int main(void) {
     assert(config_get_wifi(ssid, sizeof ssid, pass, sizeof pass));
     assert(!strcmp(ssid, "portal-network"));
     assert(!config_take_ble_recovery());
+    assert(config_save_screen_mode(false, NULL) == ESP_OK);
+    assert(!config_screen_is_bluetooth() && !config_get_photo_key(read_key));
+    assert(config_save_screen_mode(true, photo_key) == ESP_OK);
     assert(config_factory_reset() == ESP_OK);
+    assert(!config_screen_is_bluetooth() && !config_get_photo_key(read_key));
     assert(!config_get_wifi(ssid, sizeof ssid, pass, sizeof pass));
     config_get_device_token(token, sizeof token); assert(!token[0]);
     assert(config_get_waveform(2) == 2);

--- a/firmware/test/test_manual_mode.c
+++ b/firmware/test/test_manual_mode.c
@@ -1,0 +1,41 @@
+// test_manual_mode.c — host unit test for the pure Manual-mode wake decision (manual_core.h).
+// cc firmware/test/test_manual_mode.c -Ifirmware/main -o /tmp/t && /tmp/t
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 varanu5 <https://github.com/varanu5>
+#include <assert.h>
+#include <stdio.h>
+#include "manual_core.h"
+
+int main(void) {
+    manual_decision_t d;
+
+    // Healthy battery + a user (button) wake -> advertise for a photo, no repaint.
+    d = manual_decide(/*user_wake*/true, LOWBATT_NORMAL, /*was_locked*/false);
+    assert(d.run_photo && d.paint == MANUAL_PAINT_NONE);
+
+    // Healthy battery + the 24 h poll timer (no user) -> just checked the cell, do nothing.
+    d = manual_decide(/*user_wake*/false, LOWBATT_NORMAL, /*was_locked*/false);
+    assert(!d.run_photo && d.paint == MANUAL_PAINT_NONE);
+
+    // Battery just went low (ARM) -> paint the charge splash, never bring up the radio,
+    // even on a user wake (a weak cell must not run a BLE transfer).
+    d = manual_decide(/*user_wake*/true, LOWBATT_ARM, /*was_locked*/false);
+    assert(!d.run_photo && d.paint == MANUAL_PAINT_LOWBATT);
+
+    // Still low on the next poll (STAY_LOW) -> keep polling, no repaint, no radio.
+    d = manual_decide(/*user_wake*/false, LOWBATT_STAY_LOW, /*was_locked*/true);
+    assert(!d.run_photo && d.paint == MANUAL_PAINT_NONE);
+
+    // Recovered after charging (was locked, now NORMAL) + a user wake -> clear the splash
+    // with the "ready" screen AND advertise so a photo can be sent right away.
+    d = manual_decide(/*user_wake*/true, LOWBATT_NORMAL, /*was_locked*/true);
+    assert(d.run_photo && d.paint == MANUAL_PAINT_READY);
+
+    // Recovered on the 24 h poll (no user present) -> clear the splash to "ready" so the
+    // user sees it recovered, but do not advertise (nobody is here to send a photo).
+    d = manual_decide(/*user_wake*/false, LOWBATT_NORMAL, /*was_locked*/true);
+    assert(!d.run_photo && d.paint == MANUAL_PAINT_READY);
+
+    printf("test_manual_mode: all assertions passed\n");
+    return 0;
+}

--- a/tools/test_host.sh
+++ b/tools/test_host.sh
@@ -11,7 +11,7 @@ for name in battpct epd_tempcomp lowbatt rest_button maintenance_button; do
         "firmware/test/test_$name.c" -lm -o "$BUILD/$name"
     "$BUILD/$name"
 done
-for name in fb2bpp provision_form mqtt_parse; do
+for name in fb2bpp provision_form mqtt_parse ble_photo; do
     cc -std=c11 -Wall -Wextra -Werror -Ifirmware/main \
         "firmware/test/test_$name.c" "firmware/main/$name.c" -o "$BUILD/$name"
     "$BUILD/$name"

--- a/tools/test_host.sh
+++ b/tools/test_host.sh
@@ -6,7 +6,7 @@ trap 'rm -rf "$BUILD"' EXIT HUP INT TERM
 IDF="${IDF_PATH:-$HOME/.platformio/packages/framework-espidf}"
 MBEDTLS="$IDF/components/mbedtls/mbedtls"
 
-for name in battpct epd_tempcomp lowbatt rest_button maintenance_button; do
+for name in battpct epd_tempcomp lowbatt manual_mode rest_button maintenance_button; do
     cc -std=c11 -Wall -Wextra -Werror -Ifirmware/main \
         "firmware/test/test_$name.c" -lm -o "$BUILD/$name"
     "$BUILD/$name"


### PR DESCRIPTION
This adds a Screen Mode setting in Companion's Bluetooth Maintenance: **Automatic (Wi-Fi)** or **Manual (Bluetooth)**. Users enter maintenance with a 10-second hold (release before 20 seconds) and authorize their iPhone when enabling Bluetooth mode.

With Companion open, a single button press wakes PicPak and makes it available for photo transfer. The app shows a small invitation; tapping Send opens the photo editor for cropping, framing, and sending directly over BLE, without a server.

In Manual mode, scheduled Wi-Fi updates and heartbeats are paused, and PicPak sleeps between button-triggered sessions. Switching back to Automatic resumes normal operation with the saved network and server settings. Leaving maintenance in Manual mode shows a short photo-sending guide instead of the Wi-Fi-oriented closing screen.

This extends the existing Tesserae BLE v2 protocol within the same firmware. Transfers are encrypted and verified before refreshing, and the app can display battery voltage, low-battery status, and refresh speed. The upstream 10-second maintenance gesture is retained.

### Implementation and compatibility

- The mode and photo authorization key are saved together in NVS. Switching to Automatic or performing Factory Reset revokes photo authorization; clearing Wi-Fi preserves it.
- A separate photo service accepts the native 400 x 300, 30,000-byte packed BWRY frame in bounded chunks. Uploads are scoped to the current connection and checked with SHA-256. Incomplete or cancelled uploads leave the displayed image intact.
- Photo sessions advertise only after a button wake: 90 seconds without an authenticated command, five minutes of authenticated inactivity, and a ten-minute absolute limit. The radio stops before the panel refreshes. The receipt confirms verified reception, not successful physical refresh.
- The existing partition layout and display waveforms are retained. No server change is required. Manual mode intentionally stops automatic server content and telemetry, so the server may show the display as stale/offline.
- Requires the matching [Companion BLE photo implementation](https://github.com/charmmmz/tesserae-companion-ios/commit/cd23e35), with [updated 10-second maintenance instructions](https://github.com/charmmmz/tesserae-companion-ios/commit/3ee3673). The full wire contract is documented in `docs/ble-photo.md`.

### Validation

- All 12 host test programs pass via `./tools/test_host.sh`, including upload bounds, ordering, duplicate chunks, connection isolation, settings persistence/error paths, revocation, maintenance gestures, and BLE crypto vectors.
- ESP32-C3 firmware build passes via `./tools/build_firmware.sh`: 1,577,728-byte application within the existing 2 MiB slot.
- Companion local validation: 119 app unit tests (one skipped), four PicPak UI journeys, and simulator build passed. UI fixtures replace the physical peripheral.
- The final revision based on upstream 0.9.4 has not yet been flashed and retested on hardware. Sleep current and battery-life improvement remain unmeasured; the hardware validation checklist is in `docs/ble-photo.md`.
